### PR TITLE
6 merchant coupon index sorted

### DIFF
--- a/app/controllers/coupons_controller.rb
+++ b/app/controllers/coupons_controller.rb
@@ -9,23 +9,19 @@ class CouponsController < ApplicationController
     @coupon = Coupon.find(params[:id])
   end
 
-  def new; end
+  def new
+  end
 
   def create
     coupon_to_create = Coupon.new(coupon_params)
-    if @merchant.active_coupon_protection?
+    if @merchant.active_coupons.size >= 5
       redirect_to new_merchant_coupon_path(@merchant)
-      ## REFACTOR with base error message, this would be more applicable if the merchant could manually choose the status,
-      ## but since it defaults to 0 it is somewhat moot
-      # flash[:alert] = "Error: #{error_message(coupon_to_create.errors)}"
-      # flash[:error] = "Error: #{coupon_to_create.errors.full_messages.to_sentence}"
       flash[:alert] = "Error: Max Number of Active Coupons Reached: 5"
     elsif coupon_to_create.save
       redirect_to merchant_coupons_path(@merchant)
     else
       redirect_to new_merchant_coupon_path(@merchant)
       flash[:alert] = "Error: #{error_message(coupon_to_create.errors)}"
-      # flash[:alert] = "Error: Max Number of Active Coupons Reached: 5"
     end
   end
 
@@ -33,7 +29,7 @@ class CouponsController < ApplicationController
     coupon_to_update = Coupon.find(params[:id])
     ## Refactor later with @merchant.active_coupon_protection? or separate helper method
     if params[:commit] == "Deactivate Coupon"
-      coupon_to_update.update(status: 1)
+      coupon_to_update.update(status: "disabled")
       # Potential Helper Method >>>>>
       if coupon_to_update.save
         redirect_to merchant_coupon_path(@merchant, coupon_to_update)
@@ -43,7 +39,7 @@ class CouponsController < ApplicationController
       end
       # Potential Helper Method <<<<<
     else
-      coupon_to_update.update(status: 0)
+      coupon_to_update.update(status: "enabled")
       if coupon_to_update.save
         redirect_to merchant_coupon_path(@merchant, coupon_to_update)
       else
@@ -62,7 +58,7 @@ class CouponsController < ApplicationController
   end
 
   def coupon_params
-    params.permit(:name, :unique_code, :discount_amount, :discount_type, :merchant_id)
-    # params.require(:coupon).permit(:id, :name, :unique_code, :discount_amount, :discount_type, :merchant_id)
+    params.permit(:name, :unique_code, :discount_amount, :discount_type, :merchant_id, :status)
+    # params.require(:merchant_id).permit(:id, :name, :unique_code, :discount_amount, :discount_type, :merchant_id)
   end
 end

--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -1,8 +1,9 @@
 class Coupon < ApplicationRecord
-  
+
   validates_presence_of :name,
                         :discount_amount,
-                        :discount_type
+                        :discount_type,
+                        :status
 
   validates :discount_amount, numericality: { only_integer: true, greater_than_or_equal_to: 1 }
 

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -10,30 +10,8 @@ class Merchant < ApplicationRecord
   has_many :transactions, through: :invoices
   has_many :coupons
 
-  # validate :max_coupons_have_not_been_reached
-  # validates :active_coupon_count, length: { maximum: 5 }
-
   enum status: [:enabled, :disabled]
 
-  # def max_coupons_have_not_been_reached
-  #   return unless active_coupon_protection? # nothing to validate
-  #   errors.add_to_base("Max Number of Acitve Coupons Reached: 5") unless merchant.active_coupon_count < merchant.maximum_amount_of_coupons
-  # end
-
-  # def active_coupon_count
-  #   coupons.where("status = 0").size
-  # end
-
-  # def maximum_amount_of_coupons
-  #   5
-  # end
-
-  # validate do
-  #   if self.active_coupon_count >= 5
-  #     errors.add(:base, "Too Many Active Coupons") if self.active_coupon_protection? == true
-  #     return
-  #   end
-  # end
 
   def favorite_customers
     transactions.joins(invoice: :customer)
@@ -89,7 +67,11 @@ class Merchant < ApplicationRecord
     items.where(status: 0)
   end
 
-  def active_coupon_protection?
-    coupons.where("coupons.status = 0").size >= 5
+  def active_coupons
+    coupons.where(status: "enabled")
+  end
+
+  def inactive_coupons
+    coupons.where(status: "disabled")
   end
 end

--- a/app/views/coupons/index.html.erb
+++ b/app/views/coupons/index.html.erb
@@ -11,17 +11,28 @@
   </div> %>
 </div>
 
-<div class="mr-auto col-sm-6">
-  <ul>
-    <section id="<%= @merchant.id %>-coupons">
-      <p><% @coupons.each do |coupon| %>
-        <% if coupon.discount_type == "percentage" %>
-          <li>Coupon Name: <%= link_to "#{coupon.name}", merchant_coupon_path(@merchant, coupon) %> | Discount Amount: <%= number_to_percentage(coupon.discount_amount, precision: 0) %> off</li>
-        <% elsif coupon.discount_type == "dollars" %>
-          <li>Coupon Name: <%= link_to "#{coupon.name}", merchant_coupon_path(@merchant, coupon) %> | Discount Amount: <%= number_to_currency(coupon.discount_amount, precision: 0) %> off</li>
-        <% end %>
+<div id="inactive-coupons">
+  <h4>Inactive Coupons</h4>
+  <p>
+    <% @merchant.inactive_coupons.each do |coupon| %>
+      <% if coupon.discount_type == "percentage" %>
+        <li>Coupon Name: <%= link_to "#{coupon.name}", merchant_coupon_path(@merchant, coupon) %> | Discount Amount: <%= number_to_percentage(coupon.discount_amount, precision: 0) %> off</li>
+      <% elsif coupon.discount_type == "dollars" %>
+        <li>Coupon Name: <%= link_to "#{coupon.name}", merchant_coupon_path(@merchant, coupon) %> | Discount Amount: <%= number_to_currency(coupon.discount_amount, precision: 0) %> off</li>
       <% end %>
-      </p>
-    </section>
-  </ul>
+    <% end %>
+  </p>
+</div>
+
+<div id="active-coupons">
+  <h4>Active Coupons</h4>
+  <p>
+    <% @merchant.active_coupons.each do |coupon| %>
+      <% if coupon.discount_type == "percentage" %>
+        <li>Coupon Name: <%= link_to "#{coupon.name}", merchant_coupon_path(@merchant, coupon) %> | Discount Amount: <%= number_to_percentage(coupon.discount_amount, precision: 0) %> off</li>
+      <% elsif coupon.discount_type == "dollars" %>
+        <li>Coupon Name: <%= link_to "#{coupon.name}", merchant_coupon_path(@merchant, coupon) %> | Discount Amount: <%= number_to_currency(coupon.discount_amount, precision: 0) %> off</li>
+      <% end %>
+    <% end %>
+  </p>
 </div>

--- a/app/views/coupons/new.html.erb
+++ b/app/views/coupons/new.html.erb
@@ -14,7 +14,7 @@
   <br>
   <%= f.select :discount_type, options_for_select(["dollars", "percentage"]) %>
   <%= f.hidden_field :merchant_id, value: @merchant.id %>
-  <%= f.hidden_field :status, value: 0 %>
+  <%= f.hidden_field :status, value: "enabled" %>
   <br>
   <%= f.submit "Create new Coupon" %>
 <% end %>

--- a/spec/features/merchants/coupons/create_spec.rb
+++ b/spec/features/merchants/coupons/create_spec.rb
@@ -27,8 +27,11 @@ RSpec.describe "merchant coupon create", type: :feature do
         expect(current_path).to eq(merchant_coupons_path(@merchant1))
 
         new_coupon = Coupon.last
+        # @merchant1.reload
 
-        within "##{@merchant1.id}-coupons" do
+        visit merchant_coupons_path(@merchant1)
+
+        within "#active-coupons" do
           expect(page).to have_content("Coupon Name: #{new_coupon.name} | Discount Amount: 50% off")
         end
 

--- a/spec/features/merchants/coupons/index_spec.rb
+++ b/spec/features/merchants/coupons/index_spec.rb
@@ -8,7 +8,11 @@ RSpec.describe "merchant coupon index", type: :feature do
     @coupon_2 = @merchant1.coupons.create!(name: "$10", unique_code: "TENHC", discount_amount: 100, discount_type: 0, status: 0)
     @coupon_3 = @merchant1.coupons.create!(name: "$1,000,000", unique_code: "MILLIONHC", discount_amount: 1_000_000, discount_type: 0, status: 0)
     @coupon_4 = @merchant1.coupons.create!(name: "5%", unique_code: "FIVEPRCHC", discount_amount: 5, discount_type: 1, status: 0)
-    @coupon_5 = @merchant1.coupons.create!(name: "10%", unique_code: "TENPRCHC", discount_amount: 10, discount_type: 1, status: 0)
+    @coupon_5 = @merchant1.coupons.create!(name: "10%", unique_code: "TENPRCHC5", discount_amount: 10, discount_type: 1, status: 0)
+    @coupon_6 = @merchant1.coupons.create!(name: "10%", unique_code: "TENPRCHC6", discount_amount: 10, discount_type: 1, status: 1)
+    @coupon_7 = @merchant1.coupons.create!(name: "10%", unique_code: "TENPRCHC7", discount_amount: 10, discount_type: 1, status: 1)
+    @coupon_8 = @merchant1.coupons.create!(name: "10%", unique_code: "TENPRCHC8", discount_amount: 10, discount_type: 1, status: 1)
+    @coupon_9 = @merchant1.coupons.create!(name: "10%", unique_code: "TENPRCHC9", discount_amount: 10, discount_type: 1, status: 1)
 
     @merchant2 = Merchant.create!(name: "Nail Care")
 
@@ -20,47 +24,28 @@ RSpec.describe "merchant coupon index", type: :feature do
 
     visit merchant_coupons_path(@merchant1)
   end
-  
+
   it "shows the merchant's coupons" do
     expect(page).to have_content("#{@merchant1.name}'s Coupons")
 
-    within "##{@merchant1.id}-coupons" do
+    within "#active-coupons" do
       expect(page).to have_content("Coupon Name: #{@coupon_1.name} | Discount Amount: $#{@coupon_1.discount_amount} off")
       expect(page).to have_content("Coupon Name: #{@coupon_2.name} | Discount Amount: $#{@coupon_2.discount_amount} off")
       expect(page).to have_content("Coupon Name: #{@coupon_3.name} | Discount Amount: $1,000,000 off")
       expect(page).to have_content("Coupon Name: #{@coupon_4.name} | Discount Amount: 5% off")
       expect(page).to have_content("Coupon Name: #{@coupon_5.name} | Discount Amount: 10% off")
-      # Could refactor later to include spec helper to utilize view-helpers...
-      # module ViewHelpers
-      #   def h
-      #     ViewHelper.instance
-      #   end
-
-      #   class ViewHelper
-      #     include Singleton
-      #     include ActionView::Helpers::NumberHelper
-      #     include ApplicationHelper
-      #   end
-      # end
-
-      # RSpec.configure do |config|
-      #   config.include ViewHelpers
-      # end
-      # xample_spec.rb
-      # require 'rails_helper'
-
-      # feature 'some feature' do
-      #   scenario 'can see the percentage' do
-      #     savings = # Use rails view helpers freely in spec!
-      #       h.number_to_percentage(3.00, strip_insignificant_zeros: true)
-      #     expect(savings).to eq "3%"
-      #   end
-      # end
       expect(page).to_not have_content("Coupon Name: #{@coupon_6.name} | Discount Amount: $#{@coupon_6.discount_amount} off")
+      # REFACTOR: allow spec/rails helper to utilize view-helpers..
     end
   end
 
   it "has a link to create a new coupon" do
     click_link("Create New Coupon", href: new_merchant_coupon_path(@merchant1))
+  end
+
+  it "shows merchant active and inactive coupons" do
+    within "#active-coupons" do
+      expect(page).to have_content(@coupon_1.name)
+    end
   end
 end

--- a/spec/models/coupon_spec.rb
+++ b/spec/models/coupon_spec.rb
@@ -5,26 +5,27 @@ RSpec.describe Coupon, type: :model do
     it { should validate_presence_of(:name).on(:create) }
     it { should validate_presence_of(:discount_amount).on(:create) }
     it { should validate_presence_of(:discount_type).on(:create) }
+    it { should validate_presence_of(:status).on(:create) }
     it { should validate_numericality_of(:discount_amount).on(:create) }
 
     it "validates the uniqueness of a unique code for dollar discount type" do
       merchant = Merchant.create!(name: "Test Merchant")
-      Coupon.create!(name: "Foo", unique_code: "BOGO", discount_amount: 100, discount_type: 0, merchant_id: merchant.id)
-      foo = Coupon.new(name: "Foo", unique_code: "BOGO", discount_amount: 100, discount_type: 0, merchant_id: merchant.id)
+      Coupon.create!(name: "Foo", unique_code: "BOGO", discount_amount: 100, discount_type: 0, status: 0, merchant_id: merchant.id)
+      foo = Coupon.new(name: "Foo", unique_code: "BOGO", discount_amount: 100, discount_type: 0, status: 0, merchant_id: merchant.id)
       expect(foo).to_not be_valid
     end
 
     it "validates the uniqueness of a unique code for percentage discount type" do
       merchant = Merchant.create!(name: "Test Merchant")
-      Coupon.create!(name: "Foo", unique_code: "BOGO", discount_amount: 100, discount_type: 1, merchant_id: merchant.id)
-      foo = Coupon.new(name: "Foo", unique_code: "BOGO", discount_amount: 100, discount_type: 1, merchant_id: merchant.id)
+      Coupon.create!(name: "Foo", unique_code: "BOGO", discount_amount: 100, discount_type: 1, status: 0, merchant_id: merchant.id)
+      foo = Coupon.new(name: "Foo", unique_code: "BOGO", discount_amount: 100, discount_type: 1, status: 0, merchant_id: merchant.id)
       expect(foo).to_not be_valid
     end
 
     it "validates the discount amount is greater than 0" do
       merchant = Merchant.create!(name: "Test Merchant")
-      Coupon.create!(name: "Foo", unique_code: "BOGO", discount_amount: 100, discount_type: 0, merchant_id: merchant.id)
-      foo = Coupon.new(name: "Foo", unique_code: "BOGO50", discount_amount: 0, discount_type: 0, merchant_id: merchant.id)
+      Coupon.create!(name: "Foo", unique_code: "BOGO", discount_amount: 100, discount_type: 0, status: 0, merchant_id: merchant.id)
+      foo = Coupon.new(name: "Foo", unique_code: "BOGO50", discount_amount: 0, discount_type: 0, status: 0, merchant_id: merchant.id)
       expect(foo).to_not be_valid
     end
   end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -6,8 +6,8 @@ describe Merchant do
 
     it "shows that a coupon can be linked to a merchant" do
       linked_merchant = Merchant.create!(name: "Linked Merchant")
-      Coupon.create!(name: "Foo", unique_code: "BOGO", discount_amount: 100, discount_type: 0, merchant_id: linked_merchant.id)
-      foo = Coupon.new(name: "Foo", unique_code: "BOGO", discount_amount: 100, discount_type: 0, merchant_id: linked_merchant.id)
+      Coupon.create!(name: "Foo", unique_code: "BOGO", discount_amount: 100, discount_type: 0, status: 0, merchant_id: linked_merchant.id)
+      foo = Coupon.new(name: "Foo", unique_code: "BOGO", discount_amount: 100, discount_type: 0, status: 0, merchant_id: linked_merchant.id)
       expect(foo).to_not be_valid
     end
 
@@ -141,7 +141,7 @@ describe Merchant do
       actual = Merchant.top_merchants.map do |result|
         result.name
       end
-      expect(actual).to eq([@merchant1.name, @merchant3.name, @merchant4.name, @merchant5.name, @merchant6.name])
+      expect(actual).to match_array([@merchant1.name, @merchant3.name, @merchant4.name, @merchant5.name, @merchant6.name])
     end
   end
 
@@ -225,16 +225,46 @@ describe Merchant do
       expect(@merchant2.disabled_items).to eq([@item_5, @item_6])
     end
 
-    it "active_coupon_protection?" do
+    # it "active_coupon_protection?" do
+    #   merchant4 = Merchant.create!(name: "Hair Care")
+
+    #   coupon_1 = merchant4.coupons.create!(name: "Five Dollars", unique_code: "FIVEHC", discount_amount: 5, discount_type: 0, status: 0)
+    #   coupon_2 = merchant4.coupons.create!(name: "Ten Dollars", unique_code: "TENHC", discount_amount: 10, discount_type: 0, status: 0)
+    #   coupon_3 = merchant4.coupons.create!(name: "Five Percent", unique_code: "FIVEPRCHC", discount_amount: 5, discount_type: 1, status: 0)
+    #   coupon_4 = merchant4.coupons.create!(name: "Ten Percent", unique_code: "TENPRCHC", discount_amount: 10, discount_type: 1, status: 0)
+    #   coupon_5 = merchant4.coupons.create!(name: "Deactivated", unique_code: "OLDHC", discount_amount: 20, discount_type: 1, status: 0)
+
+    #   expect(merchant4.active_coupon_protection?).to be(true)
+    # end
+
+    it "#active_coupons" do
       merchant4 = Merchant.create!(name: "Hair Care")
 
       coupon_1 = merchant4.coupons.create!(name: "Five Dollars", unique_code: "FIVEHC", discount_amount: 5, discount_type: 0, status: 0)
       coupon_2 = merchant4.coupons.create!(name: "Ten Dollars", unique_code: "TENHC", discount_amount: 10, discount_type: 0, status: 0)
       coupon_3 = merchant4.coupons.create!(name: "Five Percent", unique_code: "FIVEPRCHC", discount_amount: 5, discount_type: 1, status: 0)
       coupon_4 = merchant4.coupons.create!(name: "Ten Percent", unique_code: "TENPRCHC", discount_amount: 10, discount_type: 1, status: 0)
-      coupon_5 = merchant4.coupons.create!(name: "Deactivated", unique_code: "OLDHC", discount_amount: 20, discount_type: 1, status: 0)
+      coupon_5 = merchant4.coupons.create!(name: "Old", unique_code: "OLDHC", discount_amount: 20, discount_type: 1, status: 0)
+      coupon_6 = merchant4.coupons.create!(name: "Deactivated", unique_code: "OLDHC6", discount_amount: 20, discount_type: 1, status: 1)
+      coupon_7 = merchant4.coupons.create!(name: "Deactivated", unique_code: "OLDHC7", discount_amount: 20, discount_type: 1, status: 1)
+      coupon_8 = merchant4.coupons.create!(name: "Deactivated", unique_code: "OLDHC8", discount_amount: 20, discount_type: 1, status: 1)
 
-      expect(merchant4.active_coupon_protection?).to be(true)
+      expect(merchant4.active_coupons).to eq([coupon_1, coupon_2, coupon_3, coupon_4, coupon_5])
+    end
+
+    it "#inactive_coupons" do
+      merchant4 = Merchant.create!(name: "Hair Care")
+
+      coupon_1 = merchant4.coupons.create!(name: "Five Dollars", unique_code: "FIVEHC", discount_amount: 5, discount_type: 0, status: 0)
+      coupon_2 = merchant4.coupons.create!(name: "Ten Dollars", unique_code: "TENHC", discount_amount: 10, discount_type: 0, status: 0)
+      coupon_3 = merchant4.coupons.create!(name: "Five Percent", unique_code: "FIVEPRCHC", discount_amount: 5, discount_type: 1, status: 0)
+      coupon_4 = merchant4.coupons.create!(name: "Ten Percent", unique_code: "TENPRCHC", discount_amount: 10, discount_type: 1, status: 0)
+      coupon_5 = merchant4.coupons.create!(name: "Old", unique_code: "OLDHC", discount_amount: 20, discount_type: 1, status: 0)
+      coupon_6 = merchant4.coupons.create!(name: "Deactivated", unique_code: "OLDHC6", discount_amount: 20, discount_type: 1, status: 1)
+      coupon_7 = merchant4.coupons.create!(name: "Deactivated", unique_code: "OLDHC7", discount_amount: 20, discount_type: 1, status: 1)
+      coupon_8 = merchant4.coupons.create!(name: "Deactivated", unique_code: "OLDHC8", discount_amount: 20, discount_type: 1, status: 1)
+
+      expect(merchant4.inactive_coupons).to eq([coupon_6, coupon_7, coupon_8])
     end
   end
 end


### PR DESCRIPTION
## Functionality
Removed a lot of previous leftover comments, still need to get custom validation errors to show
all functionality from US6 complete:
```
6. Merchant Coupon Index Sorted

As a merchant
When I visit my coupon index page
I can see that my coupons are separated between active and inactive coupons. 
```

## Test Coverage @ ~100% ✅ 
```zsh
garrettgregor ~/turing_work/2mod/projects/b2-final-starter-7 [6-merchant-coupon-index-sorted] $ berf
..................................................................

Finished in 5.17 seconds (files took 1.73 seconds to load)
66 examples, 0 failures

Coverage report generated for RSpec to /Users/garrettgregor/turing_work/2mod/projects/b2-final-starter-7/coverage. 1049 / 1052 LOC (99.71%) covered.
garrettgregor ~/turing_work/2mod/projects/b2-final-starter-7 [6-merchant-coupon-index-sorted] $ berm
.................................................................

Finished in 1.39 seconds (files took 1.56 seconds to load)
65 examples, 0 failures

Coverage report generated for RSpec to /Users/garrettgregor/turing_work/2mod/projects/b2-final-starter-7/coverage. 538 / 539 LOC (99.81%) covered.
garrettgregor ~/turing_work/2mod/projects/b2-final-starter-7 [6-merchant-coupon-index-sorted] $ ber
...................................................................................................................................

Finished in 7.33 seconds (files took 1.37 seconds to load)
131 examples, 0 failures

Coverage report generated for RSpec to /Users/garrettgregor/turing_work/2mod/projects/b2-final-starter-7/coverage. 1478 / 1481 LOC (99.8%) covered.
garrettgregor ~/turing_work/2mod/projects/b2-final-starter-7 [6-merchant-coupon-index-sorted] $ 
```