### PR TITLE
8 admin invoice show subtotal grandtotal

### DIFF
--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -13,7 +13,11 @@
     </section>
       <% end %>
   <p>Created on: <%= @invoice.created_at.strftime("%A, %B %d, %Y") %>
-  <p>Total Revenue: <%= number_to_currency(@invoice.sub_total) %>
+  <p>Sub-Total: <%= number_to_currency(@invoice.sub_total) %></p>
+  <% if @invoice.coupon.present? %>
+    <p>Coupon Name: <%= @invoice.coupon.name %> || Coupon Code: <%= @invoice.coupon.unique_code %></p>
+  <% end %>
+  <p>Grand Total: <%= number_to_currency(@invoice.grand_total_revenue) %></p>
 
   <h4>Customer:</h4>
     <%= @invoice.customer.first_name %> <%= @invoice.customer.last_name %><br>


### PR DESCRIPTION
## Functionality
had to change some tests in order to pass - passed with invoice test in the same way though so 🤷🏻‍♂️ 🤔 😠 
all functionality from US2 complete:
```
8. Admin Invoice Show Page: Subtotal and Grand Total Revenues

As an admin
When I visit one of my admin invoice show pages
I see the name and code of the coupon that was used (if there was a coupon applied)
And I see both the subtotal revenue from that invoice (before coupon) and the grand total revenue (after coupon) for this invoice.
```

## Test Coverage @ 99.81% 🥈  
```zsh
garrettgregor ~/turing_work/2mod/projects/b2-final-starter-7 [8-admin-invoice-show-subtotal-grandtotal] $ berf
....................................................................

Finished in 4.47 seconds (files took 1.35 seconds to load)
68 examples, 0 failures

Coverage report generated for RSpec to /Users/garrettgregor/turing_work/2mod/projects/b2-final-starter-7/coverage. 1075 / 1081 LOC (99.44%) covered.
garrettgregor ~/turing_work/2mod/projects/b2-final-starter-7 [8-admin-invoice-show-subtotal-grandtotal] $ berm
........................................................................

Finished in 1.47 seconds (files took 1.33 seconds to load)
72 examples, 0 failures

Coverage report generated for RSpec to /Users/garrettgregor/turing_work/2mod/projects/b2-final-starter-7/coverage. 614 / 615 LOC (99.84%) covered.
garrettgregor ~/turing_work/2mod/projects/b2-final-starter-7 [8-admin-invoice-show-subtotal-grandtotal] $ ber
............................................................................................................................................

Finished in 5.99 seconds (files took 1.41 seconds to load)
140 examples, 0 failures

Coverage report generated for RSpec to /Users/garrettgregor/turing_work/2mod/projects/b2-final-starter-7/coverage. 1573 / 1576 LOC (99.81%) covered.
garrettgregor ~/turing_work/2mod/projects/b2-final-starter-7 [8-admin-invoice-show-subtotal-grandtotal] $ 
```